### PR TITLE
Fix: Show all approvers from same CODEOWNERS group

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1640,7 +1640,21 @@ function App() {
                         </h3>
                         {!group.needsApproval && (
                           <span className='approved-by'>
-                            {group.approverType === 'team' ? (
+                            {group.allGroupApprovers && group.allGroupApprovers.length > 0 ? (
+                              group.allGroupApprovers.length === 1 ? (
+                                group.approverType === 'team' ? (
+                                  <>
+                                    Approved by @{group.allGroupApprovers[0]} (member of{' '}
+                                    {group.teamName})
+                                  </>
+                                ) : (
+                                  <>Approved by @{group.allGroupApprovers[0]}</>
+                                )
+                              ) : (
+                                <>Approved by @{group.allGroupApprovers.join(', @')}</>
+                              )
+                            ) : // Fallback to original approvedBy field
+                            group.approverType === 'team' ? (
                               <>
                                 Approved by @{group.approvedBy} (member of {group.teamName})
                               </>
@@ -1658,11 +1672,13 @@ function App() {
                         <div className='users-grid'>
                           {group.ownerDetails.map(user => {
                             const isApproved =
-                              !group.needsApproval &&
-                              (user.username === group.approvedBy ||
-                                (user.type === 'team' &&
-                                  (group.teamName === user.username ||
-                                    group.teamName?.endsWith(user.name))));
+                              (!group.needsApproval &&
+                                group.allGroupApprovers &&
+                                group.allGroupApprovers.includes(user.username)) ||
+                              user.username === group.approvedBy ||
+                              (user.type === 'team' &&
+                                (group.teamName === user.username ||
+                                  group.teamName?.endsWith(user.name)));
                             const approvedMembers =
                               user.type === 'team' &&
                               (group.teamName === user.username ||
@@ -1786,7 +1802,21 @@ function App() {
                         </h3>
                         {!group.needsApproval && (
                           <span className='approved-by'>
-                            {group.approverType === 'team' ? (
+                            {group.allGroupApprovers && group.allGroupApprovers.length > 0 ? (
+                              group.allGroupApprovers.length === 1 ? (
+                                group.approverType === 'team' ? (
+                                  <>
+                                    Approved by @{group.allGroupApprovers[0]} (member of{' '}
+                                    {group.teamName})
+                                  </>
+                                ) : (
+                                  <>Approved by @{group.allGroupApprovers[0]}</>
+                                )
+                              ) : (
+                                <>Approved by @{group.allGroupApprovers.join(', @')}</>
+                              )
+                            ) : // Fallback to original approvedBy field
+                            group.approverType === 'team' ? (
                               <>
                                 Approved by @{group.approvedBy} (member of {group.teamName})
                               </>
@@ -1817,11 +1847,13 @@ function App() {
                         <div className='users-grid'>
                           {group.ownerDetails.map(user => {
                             const isApproved =
-                              !group.needsApproval &&
-                              (user.username === group.approvedBy ||
-                                (user.type === 'team' &&
-                                  (group.teamName === user.username ||
-                                    group.teamName?.endsWith(user.name))));
+                              (!group.needsApproval &&
+                                group.allGroupApprovers &&
+                                group.allGroupApprovers.includes(user.username)) ||
+                              user.username === group.approvedBy ||
+                              (user.type === 'team' &&
+                                (group.teamName === user.username ||
+                                  group.teamName?.endsWith(user.name)));
                             const approvedMembers =
                               user.type === 'team' &&
                               (group.teamName === user.username ||

--- a/server/index.js
+++ b/server/index.js
@@ -1270,25 +1270,31 @@ app.post('/api/pr-approvers', async (req, res) => {
       let approverType = 'individual'; // 'individual' or 'team'
       let teamName = null;
       let approvedTeamMembers = [];
+      const allGroupApprovers = []; // Track all approvers from this group
 
       // Check each owner (individual or team) for approval
       for (const owner of owners) {
         if (approvedBy.has(owner)) {
           // Direct individual approval
           hasApproval = true;
-          approver = owner;
-          approverType = 'individual';
-          break;
+          allGroupApprovers.push(owner);
+          if (!approver) {
+            approver = owner; // Set first approver as primary
+            approverType = 'individual';
+          }
+          // Don't break - continue to find all approvers in this group
         } else if (owner.includes('/')) {
           // Check if this is a team and if any approver is a team member
           const teamApprovers = checkTeamApproval(owner, approvedBy);
           if (teamApprovers) {
             hasApproval = true;
-            approver = teamApprovers[0]; // Primary approver for display
-            approvedTeamMembers = teamApprovers; // All approved team members
-            approverType = 'team';
-            teamName = owner;
-            break;
+            if (!approver) {
+              approver = teamApprovers[0]; // Primary approver for display
+              approvedTeamMembers = teamApprovers; // All approved team members
+              approverType = 'team';
+              teamName = owner;
+            }
+            // Don't break - continue to find all approvers in this group
           }
         }
       }
@@ -1315,6 +1321,7 @@ app.post('/api/pr-approvers', async (req, res) => {
           approverType,
           teamName,
           approvedTeamMembers,
+          allGroupApprovers, // Include all approvers from this group
         });
       }
     }


### PR DESCRIPTION
# Fix: Show all approvers from same CODEOWNERS group

## 🎯 **Overview**
Fixes a bug where only the first approver from a CODEOWNERS group was displayed in the grouped approval analysis, hiding other approvers from the same group.

## 🐛 **Problem**
When multiple people from the same CODEOWNERS group approved a PR, only the first approver found would be displayed in the grouped analysis. This was due to early `break` statements in the approval checking loop.

**Example:** 
- Both `nvelickovicTT` and `rdjogoTT` approved PR tenstorrent/tt-metal#23991
- Both appeared in "all possible reviewers" ✅
- Only one showed in grouped analysis ❌

## 🔧 **Solution**
- **Removed early `break` statements** in approval checking loop
- **Added `allGroupApprovers` array** to track all approvers from each group
- **Continue checking all owners** in a group instead of stopping at first match
- **Maintain backward compatibility** with existing `approver` field

## 📋 **Changes Made**
### `server/index.js`:
1. Added `allGroupApprovers` array to track all approvers from each group
2. Modified approval checking logic to continue searching after finding first approver
3. Collect all individual approvers in `allGroupApprovers.push(owner)`
4. Include `allGroupApprovers` in the response for UI consumption

### Key Code Changes:
```javascript
// Before: Only first approver found
if (approvedBy.has(owner)) {
  hasApproval = true;
  approver = owner;
  break; // ❌ Early exit
}

// After: All approvers collected
if (approvedBy.has(owner)) {
  hasApproval = true;
  allGroupApprovers.push(owner);
  if (!approver) {
    approver = owner; // Set first as primary
  }
  // Continue to find all approvers
}
```

## ✅ **Testing**
- [x] All existing tests pass
- [x] Linting and formatting checks pass
- [x] Manual testing with PR tenstorrent/tt-metal#23991
- [x] Backward compatibility maintained

## 📊 **Impact**
- **UI Improvement**: Users can now see all approvers from the same group
- **Data Accuracy**: Complete approval information is now available
- **Transparency**: Better visibility into who has approved changes

## 🔗 **Related Issues**
Fixes #36

## 📝 **Testing Instructions**
1. Test with PR tenstorrent/tt-metal#23991
2. Verify both `nvelickovicTT` and `rdjogoTT` appear in grouped analysis
3. Confirm all existing functionality still works
4. Check that `allGroupApprovers` field is populated in API response

## 🎁 **Benefits**
- ✅ Complete approval visibility
- ✅ Improved user experience
- ✅ Better decision-making data
- ✅ Maintains backward compatibility 